### PR TITLE
Add admin mode with teacher login/logout

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,22 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, JSONResponse
 import os
+import json
+import secrets
 from pathlib import Path
+
+# Simple in-memory session store
+_sessions: dict[str, str] = {}
+
+# Load teacher credentials from JSON file
+_teachers_file = Path(__file__).parent / "teachers.json"
+with open(_teachers_file) as f:
+    _teachers_data = json.load(f)["teachers"]
+_teachers = {t["username"]: t["password"] for t in _teachers_data}
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -78,9 +89,47 @@ activities = {
 }
 
 
+def _get_authenticated_user(request: Request) -> str | None:
+    """Return the logged-in username from session cookie, or None."""
+    token = request.cookies.get("session_token")
+    return _sessions.get(token) if token else None
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
+
+
+@app.get("/auth/me")
+def auth_me(request: Request):
+    """Return current login status."""
+    user = _get_authenticated_user(request)
+    if user:
+        return {"logged_in": True, "username": user}
+    return {"logged_in": False}
+
+
+@app.post("/auth/login")
+def login(request: Request, username: str, password: str):
+    """Log in as a teacher."""
+    if _teachers.get(username) != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    token = secrets.token_hex(32)
+    _sessions[token] = username
+    response = JSONResponse({"message": f"Welcome, {username}!"})
+    response.set_cookie("session_token", token, httponly=True, samesite="strict")
+    return response
+
+
+@app.post("/auth/logout")
+def logout(request: Request):
+    """Log out the current teacher."""
+    token = request.cookies.get("session_token")
+    if token:
+        _sessions.pop(token, None)
+    response = JSONResponse({"message": "Logged out"})
+    response.delete_cookie("session_token")
+    return response
 
 
 @app.get("/activities")
@@ -89,8 +138,10 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, request: Request):
+    """Sign up a student for an activity (teacher only)"""
+    if not _get_authenticated_user(request):
+        raise HTTPException(status_code=403, detail="Only teachers can register students")
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +162,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, request: Request):
+    """Unregister a student from an activity (teacher only)"""
+    if not _get_authenticated_user(request):
+        raise HTTPException(status_code=403, detail="Only teachers can unregister students")
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,81 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authBtn = document.getElementById("auth-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authStatus = document.getElementById("auth-status");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginError = document.getElementById("login-error");
+  const signupContainer = document.getElementById("signup-container");
+
+  let isLoggedIn = false;
+
+  // Check current auth status on load
+  async function checkAuth() {
+    const response = await fetch("/auth/me");
+    const data = await response.json();
+    setAuthState(data.logged_in, data.username);
+  }
+
+  function setAuthState(loggedIn, username) {
+    isLoggedIn = loggedIn;
+    if (loggedIn) {
+      authBtn.classList.add("hidden");
+      authStatus.textContent = `👤 ${username}`;
+      authStatus.classList.remove("hidden");
+      logoutBtn.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      authBtn.classList.remove("hidden");
+      authStatus.classList.add("hidden");
+      logoutBtn.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    fetchActivities();
+  }
+
+  // Show login modal
+  authBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  // Hide login modal
+  document.getElementById("cancel-login").addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  // Close modal on backdrop click
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) loginModal.classList.add("hidden");
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    const response = await fetch(
+      `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+      { method: "POST" }
+    );
+    if (response.ok) {
+      loginModal.classList.add("hidden");
+      setAuthState(true, username);
+    } else {
+      const data = await response.json();
+      loginError.textContent = data.detail || "Login failed";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", async () => {
+    await fetch("/auth/logout", { method: "POST" });
+    setAuthState(false, null);
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -21,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Create participants HTML with delete icons only for teachers
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +105,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${isLoggedIn ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -156,5 +231,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  checkAuth();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-area">
+        <button id="auth-btn" class="auth-btn" title="Teacher Login">👤 Login</button>
+        <span id="auth-status" class="auth-status hidden"></span>
+        <button id="logout-btn" class="auth-btn hidden">Logout</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login">Cancel</button>
+          </div>
+          <div id="login-error" class="error hidden"></div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,7 +48,7 @@
         </div>
       </section>
 
-      <section id="signup-container">
+      <section id="signup-container" class="hidden">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,82 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
+}
+
+#auth-area {
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.auth-btn:hover {
+  background-color: rgba(255, 255, 255, 0.35);
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.auth-status {
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 5px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #757575;
+}
+
+.modal-actions button[type="button"]:hover {
+  background-color: #616161;
 }
 
 main {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "msmith",
+      "password": "teacher123"
+    },
+    {
+      "username": "jdoe",
+      "password": "teacher456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves #5

Students were removing each other from activities. This PR adds teacher-only access control so only authenticated teachers can register or unregister students.

## Changes

- **`src/teachers.json`** — stores teacher credentials (username/password)
- **`src/app.py`** — added `/auth/me`, `/auth/login`, `/auth/logout` endpoints; protected `/signup` and `/unregister` routes with a 403 for unauthenticated requests
- **`src/static/index.html`** — added 👤 Login button in the header and a login modal
- **`src/static/app.js`** — checks auth state on load, shows/hides signup form and ❌ buttons based on login state
- **`src/static/styles.css`** — styles for auth area in header and login modal

## Behaviour

- **Students (not logged in):** can view all activities and participant lists, but cannot register or unregister anyone
- **Teachers (logged in):** see the signup form and unregister buttons, and can manage student enrollment